### PR TITLE
ci: add git-gateway backend configuration to admin config

### DIFF
--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -1,3 +1,7 @@
+backend:
+  name: git-gateway
+  branch: main # Branch to update (optional; defaults to master)
+
 media_folder: 'src/assets/blog' # Location where files will be stored in the repo
 public_folder: 'src/assets/blog' # The src attribute for uploaded media
 collections:


### PR DESCRIPTION
This commit introduces the git-gateway backend configuration to the admin config file, specifying the branch as 'main'. This change is necessary to ensure proper integration with the CMS backend.